### PR TITLE
feat: enable blank issues for improved user engagement

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -20,7 +20,7 @@
 
 # https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
 
   - name: "🏆 [DISCUSSÕES] Certificado"


### PR DESCRIPTION
This pull request makes a small configuration change to the issue template settings. The change enables the use of blank issues, allowing users to open issues without selecting a predefined template.

* Enabled blank issues by setting `blank_issues_enabled: true` in `.github/ISSUE_TEMPLATE/config.yml`