### PR TITLE
fix: update availability time for Empreendedorismo mentorship

### DIFF
--- a/docs/quero/mentoria.md
+++ b/docs/quero/mentoria.md
@@ -43,4 +43,4 @@ As mentorias e aulas particulares serão realizadas online, através de ferramen
 | Frontend e Arquitetura | Guilherme Siquinelli | Mentoria para quem está com os primeiros passos em Frontend e também para quem quer entender sobre arquitetura. | Quarta das 19h às 21h |
 | Backend e .NET | Matheus Luis | Para pessoas que desejam aprender e seguir carreira dentro do Ambiente .NET | Segunda, Quarta e Sexta das 19h às 20h |
 | Como organizar eventos na sua cidade | [Ivo Batistela](https://github.com/byivo) | Mentoria para quem quer organizar um evento na sua própria cidade | Segunda à Sexta, 18h às 18:30h |
-| Empreendedorismo | Renan Ceratto | Mentoria para quem deseja empreender e não sabe por onde começar | Terça e Quinta das 18h às 20h |
+| Empreendedorismo | Renan Ceratto | Mentoria para quem deseja empreender e não sabe por onde começar | Quinta das 19h às 20h |


### PR DESCRIPTION
This pull request updates the schedule for the Empreendedorismo mentorship session in the `docs/quero/mentoria.md` file. The session is now offered only on Thursdays from 19h to 20h, instead of Tuesdays and Thursdays from 18h to 20h.