### PR TITLE
chore(backstage): add catalog-info.yaml for codaqui-institucional com…

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,9 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: codaqui-institucional
+  description: Site institucional da Codaqui
+spec:
+  type: website
+  owner: enderson@codaqui.dev
+  lifecycle: production


### PR DESCRIPTION
This pull request introduces a new Backstage catalog metadata file to register the institutional website project with the internal developer portal.

Backstage catalog integration:

* Added a new `catalog-info.yaml` file that defines the project as a `Component` of type `website`, sets its name and description, assigns ownership, and specifies its lifecycle as production.