### PR TITLE
chore(backstage): set owner to guests in codaqui-institucional catalo…

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,5 +5,5 @@ metadata:
   description: Site institucional da Codaqui
 spec:
   type: website
-  owner: endersonmenezes
+  owner: guests
   lifecycle: production


### PR DESCRIPTION
This pull request makes a small change to the `catalog-info.yaml` file, updating the owner of the institutional website from `endersonmenezes` to `guests`.