### PR TITLE
chore(backstage): add website and GitHub repository links to codaqui catalog

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -3,7 +3,17 @@ kind: Component
 metadata:
   name: codaqui-institucional
   description: Site institucional da Codaqui
+  links:
+    - url: https://codaqui.dev
+      title: Codaqui Site Institucional
+      icon: website
+      type: website
+    - url: https://github.com/codaqui/institucional
+      title: Codaqui Institucional GitHub Repository
+      icon: github
+      type: source
 spec:
   type: website
   owner: codaqui-conselho
   lifecycle: production
+  system: diretoria-institucional


### PR DESCRIPTION
This pull request updates the metadata for the `codaqui-institucional` component in the `catalog-info.yaml` file, enhancing its documentation and discoverability.

Metadata and documentation improvements:

* Added two new links under the `links` section: one to the official Codaqui institutional website and another to the corresponding GitHub repository.
* Specified the `system` field as `diretoria-institucional` to clarify the component's association within the organization.