### PR TITLE
docs(timeline): update 2025 section and add 2026 details for community growth and events

### DIFF
--- a/docs/timeline.md
+++ b/docs/timeline.md
@@ -3,22 +3,35 @@
 !!! tip "Nossa Jornada"
     Acompanhe os principais marcos da nossa história e como chegamos até aqui.
 
-## :material-calendar-clock: 2025 - Em Andamento
+## :material-calendar-clock: 2026
 
 !!! success "Resultados Parciais"
-    Nossos números em 2025 mostram o crescimento contínuo da nossa missão.
+    Nossos números em 2026 mostram o crescimento contínuo da nossa missão.
+
+
+### :material-presentation: Encontros
+
+- **1º Semestre**:
+- **2º Semestre**:
 
 ### :material-account-group: Comunidade
 
-- **684 membros** no Discord
-- **458 membros** no WhatsApp Principal
-- **+2000 visualizações** mensais no Site
+- 
 
-### :material-school: Educação
+## :material-calendar-clock: 2025
 
-- **14 encontros virtuais** realizados
-- **≈ 20 alunos** participando ativamente
-- **77 horas de mentorias** concluídas (totalizando **53 mentorias** e auxiliando **quase 40 pessoas**)
+
+### :material-presentation: Encontros
+
+- **1º Semestre**: 15 alunos (Aulas Virtuais)
+- **2º Semestre**: 10 alunos (Aulas Virtuais)
+- **95 mentorias realizadas totalizando 66 horas de mentoria e 45 alunos**
+
+### :material-account-group: Comunidade
+
+- **692 membros** no Discord
+- **463 membros** no WhatsApp Principal
+- **+7000 visualizações** mensais no Site
 
 ---
 


### PR DESCRIPTION
This pull request updates the `docs/timeline.md` file to provide more accurate and detailed information about the project's progress in 2025 and 2026. The changes clarify the timeline, update community statistics, and add more granular data about events and mentorship activities.

Timeline and results updates:

* Updated the section for 2026 to reflect ongoing progress, and clarified the "Resultados Parciais" to reference 2026 instead of 2025.
* Added placeholders for 2026 "Encontros" (meetings) in both semesters.

2025 detailed statistics:

* Broke down 2025 "Encontros" into first and second semesters, specifying student participation and mentorship statistics: 15 students in the first semester, 10 in the second, and 95 mentorship sessions totaling 66 hours for 45 students.
* Updated 2025 community metrics: 692 Discord members, 463 WhatsApp members, and over 7000 monthly site views.
* Removed outdated or redundant statistics and reorganized content for clarity.