### PR TITLE
fix(docs): update links to the registration form and official links i…

### DIFF
--- a/docs/blog/posts/institucional/2026_01_29_curso_gestao_produtividade.md
+++ b/docs/blog/posts/institucional/2026_01_29_curso_gestao_produtividade.md
@@ -84,8 +84,8 @@ A **Codaqui** é para todos que desejam aprender e crescer, independentemente da
 
 As inscrições já estão abertas! Acesse o formulário de inscrição:
 
-- [#Quero Estudar! - Formulário de Inscrição](../quero/estudar.md)
-- [Nossos links oficiais](../bio.md)
+- [#Quero Estudar! - Formulário de Inscrição](../../../quero/estudar.md)
+- [Nossos links oficiais](../../../bio.md)
 
 
 ## Mais Informações sobre o Danilo


### PR DESCRIPTION
This pull request updates the documentation links in the blog post about the productivity management course to ensure they point to the correct locations.

- Documentation updates:
  * Fixed relative paths for the "Formulário de Inscrição" and "Nossos links oficiais" links in `2026_01_29_curso_gestao_produtividade.md` to reference the correct directories.