### PR TITLE
Develop

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-codaqui",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "API for Codaqui Website and Intranet",
   "author": "Enderson Menezes Candido <enderson@codaqui.dev>",
   "private": true,

--- a/backend/src/stripe/stripe.service.ts
+++ b/backend/src/stripe/stripe.service.ts
@@ -439,7 +439,7 @@ export class StripeService {
         amount: item?.price?.unit_amount ?? 0,
         currency: item?.price?.currency ?? 'brl',
         communityId: sub.metadata?.communityId ?? 'tesouro-geral',
-        currentPeriodEnd: (sub as any).current_period_end ?? 0,
+        currentPeriodEnd: item?.current_period_end ?? 0,
         cancelAtPeriodEnd: sub.cancel_at_period_end,
       };
     });
@@ -471,14 +471,15 @@ export class StripeService {
       cancel_at_period_end: true, // Stripe best practice: não cancela imediatamente
     });
 
-    const currentPeriodEnd = (updated as any).current_period_end;
+    const updatedItem = updated.items.data[0];
+    const currentPeriodEnd = updatedItem?.current_period_end ?? 0;
     this.logger.log(
       `Assinatura ${subscriptionId} marcada para cancelar em ${new Date(currentPeriodEnd * 1000).toLocaleDateString('pt-BR')} (membro: ${memberId})`,
     );
 
     return {
       cancelAtPeriodEnd: updated.cancel_at_period_end,
-      currentPeriodEnd: (updated as any).current_period_end,
+      currentPeriodEnd,
     };
   }
 }


### PR DESCRIPTION
This pull request makes minor adjustments to the Stripe subscription handling in the backend service, focusing on how the end of the current billing period is determined and reported. The changes ensure that the `currentPeriodEnd` value is consistently sourced from the correct object, improving the accuracy of subscription status reporting.

Stripe subscription period handling improvements:

* Updated the retrieval of `currentPeriodEnd` in the `StripeService` to use the `current_period_end` from the relevant subscription item rather than the subscription object, both when listing subscriptions and when marking a subscription to cancel at period end. [[1]](diffhunk://#diff-345606a358b4f16114f2d15e1f77e3cc708456288dd678487c95eff039669cadL442-R442) [[2]](diffhunk://#diff-345606a358b4f16114f2d15e1f77e3cc708456288dd678487c95eff039669cadL474-R482)

Other changes:

* Incremented the backend package version from `0.0.6` to `0.0.7` in `package.json`.