### PR TITLE
feat: enhance Discord event synchronization by preserving completed events

### DIFF
--- a/scripts/sync-events.mjs
+++ b/scripts/sync-events.mjs
@@ -495,7 +495,25 @@ async function resolveDiscordEvents(config, existingEvents) {
       }
     });
 
-    return payload.map((event) => mapDiscordEvent(event, config));
+    const freshEvents = payload.map((event) => mapDiscordEvent(event, config));
+    const freshById = new Map(freshEvents.map((e) => [e.id, e]));
+
+    // Merge: keep existing past events that are no longer in the API.
+    // Discord only returns scheduled/active events — once an event ends,
+    // it disappears from the API. We preserve those as "completed".
+    const now = new Date();
+    for (const existing of existingEvents) {
+      if (!freshById.has(existing.id)) {
+        // Mark as completed if the event has already started
+        const startAt = new Date(existing.startAt);
+        if (startAt <= now && existing.status !== "canceled") {
+          existing.status = "completed";
+        }
+        freshById.set(existing.id, existing);
+      }
+    }
+
+    return [...freshById.values()];
   } catch (error) {
     console.warn(`Skipping live Discord sync for ${config.source}/${config.sourceId}:`, error.message);
     return existingEvents.length > 0 ? existingEvents : config.fallbackEvents ?? [];


### PR DESCRIPTION
This pull request improves how Discord events are synchronized by ensuring past events are preserved and marked as completed when appropriate. Previously, only scheduled or active events were returned from the Discord API, which caused completed events to disappear from the local list. The new logic merges existing events with fresh data from the API, updating the status of past events as needed.

**Discord event synchronization improvements:**

* In `resolveDiscordEvents`, added logic to merge existing events with fresh events from the API, preserving past events that are no longer returned by Discord. If an existing event has started and is not canceled, it is marked as "completed" instead of being removed.