### PR TITLE
feat(communities): support nested nav menus and migrate community pages

### DIFF
--- a/comunidades/tisocial/community.config.ts
+++ b/comunidades/tisocial/community.config.ts
@@ -5,6 +5,12 @@
  * É importado pelas páginas em `src/pages/comunidades/tisocial/`.
  */
 
+export interface NavMenuItem {
+  label: string;
+  to?: string;
+  items?: { label: string; to: string }[];
+}
+
 export interface CommunitySiteConfig {
   slug: string;
   name: string;
@@ -23,7 +29,7 @@ export interface CommunitySiteConfig {
   };
   basePath: string;
   externalLinks: { label: string; href: string }[];
-  navMenu: { label: string; to: string }[];
+  navMenu: NavMenuItem[];
   features: {
     donations: boolean;
     transparency: boolean;
@@ -97,8 +103,14 @@ const config: CommunitySiteConfig = {
   ],
   navMenu: [
     { label: "Início",        to: "/comunidades/tisocial" },
+    {
+      label: "Sobre",
+      items: [
+        { label: "Docs",   to: "/comunidades/tisocial/docs" },
+        { label: "Equipe", to: "/comunidades/tisocial/equipe" },
+      ],
+    },
     { label: "Campanhas",     to: "/comunidades/tisocial/blog" },
-    { label: "Docs",          to: "/comunidades/tisocial/docs" },
     { label: "Apoiar",        to: "/comunidades/tisocial/apoiar" },
     { label: "Transparência", to: "/comunidades/tisocial/transparencia" },
   ],

--- a/comunidades/tisocial/src/data/team.ts
+++ b/comunidades/tisocial/src/data/team.ts
@@ -1,0 +1,67 @@
+export interface Member {
+  name: string;
+  role: string;
+  specialty?: string;
+  avatar: string;
+  linkedin?: string;
+  github?: string;
+}
+
+export const equipeImpacto: Member[] = [
+  {
+    name: "Amanda Veras",
+    role: "Voluntária",
+    specialty: "Gerente de Marketing",
+    avatar: "https://media.licdn.com/dms/image/v2/D4D03AQFeL1wnvNv6Lg/profile-displayphoto-crop_800_800/B4DZx91LmtI8AI-/0/1771637619859?e=1781136000&v=beta&t=FJfcfRH7XLpXalpCVF3rXJiKSD_pGTYT7LGXVJ37R40",
+    linkedin: "https://www.linkedin.com/in/amannda-veras/"
+  },
+  {
+    name: "Ana Letícia Mania Feijó",
+    role: "Voluntária",
+    specialty: "Governança de TI",
+    avatar: "https://media.licdn.com/dms/image/v2/C4E03AQEub9czwWcZMQ/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1655991286341?e=1781136000&v=beta&t=ohzImnnePWSL69dPhUuSzQ061CBNIFMak4YzMycof6w",
+    linkedin: "https://www.linkedin.com/in/analeticiamania/"
+  },
+  {
+    name: "Caroline Fiori\n",
+    role: "Voluntária",
+    specialty: "Especialista em Employer Branding",
+    avatar: "https://media.licdn.com/dms/image/v2/D4D03AQGybeuYIn99Wg/profile-displayphoto-crop_800_800/B4DZ203tulHsAI-/0/1776856001511?e=1781136000&v=beta&t=cWxJy8Chp4aXGGQi7BnbP6vpULLur0MuerQ5MjMpO1g",
+    linkedin: "https://www.linkedin.com/in/caroline-fiori-454730b1/"
+  },
+  {
+    name: "Emerson Rafael Marchi",
+    role: "Voluntário",
+    specialty: "Encarregado de Recursos Humanos",
+    avatar: "https://media.licdn.com/dms/image/v2/C4E03AQFG-xhKvMxfkg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1622294438819?e=1781136000&v=beta&t=maZFbG-xfNaPRjxGwkExaDE1xQfYxVtfD_IgUTYyHDU",
+    linkedin: "https://www.linkedin.com/in/ermarchi/"
+  },
+  {
+    name: "Jean da Silva Baldaia",
+    role: "Voluntário",
+    specialty: "Analista de Inovação",
+    avatar: "https://media.licdn.com/dms/image/v2/D4D03AQE_aIMdseIxXA/profile-displayphoto-shrink_800_800/B4DZUV_9HNHIAc-/0/1739830842515?e=1781136000&v=beta&t=lhxR2FZiKlh5H4RNgXKKL97MBoF9lxOWVcw0Xm11Dd0",
+    linkedin: "https://www.linkedin.com/in/jeanbaldaia/"
+  },
+  {
+    name: "Júlia Nicolodi",
+    role: "Voluntária",
+    specialty: "Comunicação interna",
+    avatar: "https://media.licdn.com/dms/image/v2/D4D03AQFViOX8aGVifw/profile-displayphoto-crop_800_800/B4DZ3CLMnPKEAI-/0/1777079213022?e=1781136000&v=beta&t=JC04yfbzuSqVzCJjFNTi-_NhEoJOJ2aWz37EthtQI18",
+    linkedin: "https://www.linkedin.com/in/j%C3%BAlia-nicolodi-10a308181/"
+  },
+  {
+    name: "Renan Ceratto",
+    role: "Voluntário",
+    specialty: "O programador",
+    avatar: "https://media.licdn.com/dms/image/v2/D4D03AQEQkdwbmliqwg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1730159934068?e=1781136000&v=beta&t=VEsa9UufJCVRHHOzWcz3neSF6cjA83zMGG4YQniQCVg",
+    linkedin: "https://www.linkedin.com/in/renanceratto/"
+  },
+  {
+    name: "Você?",
+    role: "Voluntário",
+    specialty: "Impacto Social",
+    avatar: "https://github.com/ghost.png",
+    linkedin: "https://www.instagram.com/tisocialmaringa",
+  },
+];

--- a/comunidades/tisocial/src/pages/apoiar.tsx
+++ b/comunidades/tisocial/src/pages/apoiar.tsx
@@ -13,7 +13,7 @@ import {
 import VolunteerActivismIcon from "@mui/icons-material/VolunteerActivism";
 import VerifiedIcon from "@mui/icons-material/Verified";
 import DonationFlow from "@site/src/components/DonationFlow";
-import community from "@site/comunidades/tisocial/community.config";
+import community from "../../community.config";
 
 const accent = community.theme.primary;
 const accentDark = community.theme.primaryDark;

--- a/comunidades/tisocial/src/pages/equipe.tsx
+++ b/comunidades/tisocial/src/pages/equipe.tsx
@@ -1,0 +1,141 @@
+import React from "react";
+import Layout from "@theme/Layout";
+import {
+  Avatar,
+  Card,
+  CardContent,
+  CardActions,
+  Chip,
+  IconButton,
+  Grid,
+  Box,
+  Typography,
+  Divider,
+  Container,
+  Stack,
+} from "@mui/material";
+import LinkedInIcon from "@mui/icons-material/LinkedIn";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import community from "../../community.config";
+import { equipeImpacto, type Member } from "../data/team";
+
+const accent = community.theme.primary;
+const accentDark = community.theme.primaryDark;
+
+function MemberCard({ name, role, specialty, avatar, linkedin, github }: Readonly<Member>) {
+  return (
+    <Card
+      variant="outlined"
+      sx={{
+        height: "100%",
+        display: "flex",
+        flexDirection: "column",
+        transition: "all 0.2s",
+        "&:hover": { transform: "translateY(-2px)", boxShadow: 3, borderColor: accent },
+      }}
+    >
+      <CardContent sx={{ flexGrow: 1, display: "flex", flexDirection: "column", alignItems: "center", textAlign: "center", gap: 1 }}>
+        <Avatar
+          src={avatar}
+          alt={`Foto de ${name}`}
+          sx={{ width: 80, height: 80, border: "3px solid", borderColor: "divider" }}
+        />
+        <Typography variant="h6" fontWeight={700}>{name}</Typography>
+        <Chip variant="outlined" size="small" label={role} sx={{ mt: 0.5 }} />
+        {specialty && (
+          <Chip 
+            variant="filled" 
+            size="small" 
+            label={specialty} 
+            sx={{ bgcolor: accent, color: "#fff", fontWeight: 600 }}
+          />
+        )}
+      </CardContent>
+      <CardActions sx={{ justifyContent: "center", pt: 0 }}>
+        {linkedin && linkedin !== "#" && (
+          <IconButton
+            size="small"
+            component="a"
+            href={linkedin}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`LinkedIn de ${name}`}
+          >
+            <LinkedInIcon sx={{ color: accent }} />
+          </IconButton>
+        )}
+        {github && github !== "#" && (
+          <IconButton
+            size="small"
+            component="a"
+            href={github}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`GitHub de ${name}`}
+          >
+            <GitHubIcon />
+          </IconButton>
+        )}
+      </CardActions>
+    </Card>
+  );
+}
+
+export default function EquipeTiSocialPage(): React.JSX.Element {
+  return (
+    <Layout 
+      title={`Equipe — ${community.shortName}`} 
+      description={`Conheça as pessoas por trás da ${community.name}`}
+    >
+      <main>
+        <Box
+          sx={{
+            bgcolor: (t) => (t.palette.mode === "dark" ? accentDark : accent),
+            color: "#fff",
+            py: { xs: 6, md: 8 },
+          }}
+        >
+          <Container maxWidth="lg">
+            <Stack spacing={2} maxWidth={760}>
+              <Chip
+                label={community.name}
+                sx={{
+                  bgcolor: "rgba(255,255,255,0.18)",
+                  color: "#fff",
+                  width: "fit-content",
+                  fontWeight: 600,
+                }}
+              />
+              <Typography variant="h2" component="h1" fontWeight={800}>
+                Equipe de Impacto
+              </Typography>
+              <Typography variant="h6" sx={{ opacity: 0.95, fontWeight: 400 }}>
+                A T.I. Social Maringá é movida por pessoas apaixonadas por tecnologia e
+                causas sociais. Conheça quem faz as campanhas acontecerem.
+              </Typography>
+            </Stack>
+          </Container>
+        </Box>
+
+        <Container maxWidth="lg" sx={{ py: { xs: 6, md: 8 } }}>
+          <Box component="section" sx={{ mb: 8 }}>
+            <Typography variant="h4" component="h2" sx={{ mb: 1, fontWeight: 700 }}>
+              Voluntários e Liderança
+            </Typography>
+            <Typography variant="body1" color="text.secondary" sx={{ mb: 3, maxWidth: 700 }}>
+              Nossa equipe é composta por colaboradores voluntários das empresas parceiras.
+            </Typography>
+            <Divider sx={{ mb: 4 }} />
+            <Grid container spacing={3}>
+              {equipeImpacto.map((m) => (
+                <Grid key={m.name + m.role} size={{ xs: 12, sm: 6, md: 4 }}>
+                  <MemberCard {...m} />
+                </Grid>
+              ))}
+            </Grid>
+          </Box>
+        </Container>
+      </main>
+    </Layout>
+  );
+}

--- a/comunidades/tisocial/src/pages/index.tsx
+++ b/comunidades/tisocial/src/pages/index.tsx
@@ -19,8 +19,8 @@ import ArticleIcon from "@mui/icons-material/Article";
 import PaidIcon from "@mui/icons-material/Paid";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import CalendarMonthIcon from "@mui/icons-material/CalendarMonth";
-import community from "@site/comunidades/tisocial/community.config";
-import upcoming from "@site/comunidades/tisocial/src/data/upcoming.json";
+import community from "../../community.config";
+import upcoming from "../data/upcoming.json";
 
 const accent = community.theme.primary;
 const accentDark = community.theme.primaryDark;

--- a/comunidades/tisocial/src/pages/transparencia.tsx
+++ b/comunidades/tisocial/src/pages/transparencia.tsx
@@ -23,7 +23,7 @@ import FavoriteIcon from "@mui/icons-material/Favorite";
 import ReceiptLongIcon from "@mui/icons-material/ReceiptLong";
 import { type CommunityBalance, formatBRL } from "@site/src/utils/transaction";
 import TransactionTable from "@site/src/components/TransactionTable";
-import community from "@site/comunidades/tisocial/community.config";
+import community from "../../community.config";
 import { resolveApiUrl } from "@site/src/lib/api-url";
 
 const accent = community.theme.primary;

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -198,6 +198,15 @@ const config: Config = {
           },
         ]);
       }
+      // Auto-discovery of custom pages in comunidades/<slug>/src/pages/
+      entries.push([
+        "@docusaurus/plugin-content-pages",
+        {
+          id: `community-${community.slug}-pages`,
+          path: `comunidades/${community.slug}/src/pages`,
+          routeBasePath: `comunidades/${community.slug}`,
+        },
+      ]);
       return entries;
     }),
   ],

--- a/src/theme/Footer/index.tsx
+++ b/src/theme/Footer/index.tsx
@@ -52,10 +52,15 @@ export default function FooterWrapper(): React.JSX.Element | null {
               Navegar
             </Typography>
             <Stack spacing={1} sx={{ mt: 1.5 }}>
-              {community.navMenu.map((item) => (
+              {community.navMenu.flatMap((item) => {
+                if ("items" in item && item.items) {
+                  return item.items;
+                }
+                return [item];
+              }).map((item) => (
                 <Link
                   key={item.to}
-                  to={item.to}
+                  to={item.to!}
                   style={{ color: "#cbd5e1", textDecoration: "none", fontSize: "0.9rem" }}
                 >
                   {item.label}

--- a/src/theme/Navbar/Content/index.tsx
+++ b/src/theme/Navbar/Content/index.tsx
@@ -88,13 +88,26 @@ function NavbarContentLayout({
 }
 
 function buildCommunityItems(community: CommunitySiteConfig): AnyNavItem[] {
-  const left: AnyNavItem[] = community.navMenu.map((item) => ({
-    label: item.label,
-    to: item.to,
-    position: "left" as const,
-    activeBaseRegex:
-      item.to === community.basePath ? `^${community.basePath}/?$` : undefined,
-  }));
+  const left: AnyNavItem[] = community.navMenu.map((item) => {
+    if ("items" in item && item.items) {
+      return {
+        label: item.label,
+        position: "left" as const,
+        type: "dropdown" as const,
+        items: item.items.map((subItem) => ({
+          label: subItem.label,
+          to: subItem.to,
+        })),
+      };
+    }
+    return {
+      label: item.label,
+      to: item.to,
+      position: "left" as const,
+      activeBaseRegex:
+        item.to === community.basePath ? `^${community.basePath}/?$` : undefined,
+    };
+  });
   // Auth (login/logout) intentionally omitted in community context — preparing
   // for future custom-domain deployments where the auth cookie won't be shared.
   return left;

--- a/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
+++ b/src/theme/Navbar/MobileSidebar/PrimaryMenu/index.tsx
@@ -21,18 +21,30 @@ export default function PrimaryMenuWrapper(): React.JSX.Element {
     return <OriginalPrimaryMenu />;
   }
 
-  const items = community.navMenu.map((item) => ({
-    label: item.label,
-    to: item.to,
-    activeBaseRegex:
-      item.to === community.basePath ? `^${community.basePath}/?$` : undefined,
-  }));
+  const items = community.navMenu.map((item) => {
+    if ("items" in item && item.items) {
+      return {
+        label: item.label,
+        type: "dropdown" as const,
+        items: item.items.map((subItem) => ({
+          label: subItem.label,
+          to: subItem.to,
+        })),
+      };
+    }
+    return {
+      label: item.label,
+      to: item.to,
+      activeBaseRegex:
+        item.to === community.basePath ? `^${community.basePath}/?$` : undefined,
+    };
+  });
 
   return (
     <ul className="menu__list">
       {items.map((item) => (
         <NavbarItem
-          key={item.to}
+          key={item.label}
           mobile
           {...item}
           onClick={() => mobileSidebar.toggle()}


### PR DESCRIPTION
- Configure Docusaurus to auto-discover custom pages in `comunidades/<slug>/src/pages/`.
- Relocate `tisocial` pages (`index`, `apoiar`, `transparencia`) to their dedicated community folder.
- Implement dropdown menu support for nested items in the Navbar, MobileSidebar, and Footer components.
- Create a new "Equipe" page and team data structure for the `tisocial` community.
- Update `community.config.ts` to include a nested "Sobre" menu item.

# Solução de Problemas e/ou Complemento

## Metadados

Link da Discussão: <!-- link da discussão -->
Link da Issue: <!-- link da issue -->

## Descrição
Coloquei os membros do grupo em uma nova pagina de equipe em submenu.
Também fiz uma alteração na estrutura, jogando os arquivos de pagina para dentro da subpasta da comunidade.
@endersonmenezes  Caso queira que eu desfaça essa alteração de estrutura, só me avisar (aí eu deixo apenas a pg de equipe)