### PR TITLE
Develop

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-codaqui",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "API for Codaqui Website and Intranet",
   "author": "Enderson Menezes Candido <enderson@codaqui.dev>",
   "private": true,

--- a/backend/src/stripe/stripe.service.spec.ts
+++ b/backend/src/stripe/stripe.service.spec.ts
@@ -1043,6 +1043,43 @@ describe('StripeService', () => {
         expect.objectContaining({ status: 'past_due' }),
       );
     });
+
+    it('should keep business member even when githubHandle is missing in metadata', async () => {
+      stripeInstance.subscriptions.list
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 'sub_business_active_no_handle',
+              status: 'active',
+              metadata: {
+                memberId: uuid(7),
+                companyId: uuid(8),
+                entityType: 'business',
+              },
+              items: {
+                data: [
+                  {
+                    price: {
+                      recurring: { interval: 'month' },
+                    },
+                  },
+                ],
+              },
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ data: [] });
+
+      const result = await service.getBusinessMembers();
+
+      expect(result.total).toBe(1);
+      expect(result.items).toEqual([
+        {
+          memberId: uuid(7),
+          githubHandle: '',
+        },
+      ]);
+    });
   });
 
   // ─── cancelSubscription ───────────────────────────────────────────────────

--- a/backend/src/stripe/stripe.service.ts
+++ b/backend/src/stripe/stripe.service.ts
@@ -1104,8 +1104,10 @@ export class StripeService {
     return deduped
       .map((sub) => {
         const memberId = sub.metadata?.memberId ?? '';
+        // CLUB Business antigas não persistiam githubHandle no metadata.
+        // Mantemos o membro no resultado para não zerar contagens públicas.
         const githubHandle = sub.metadata?.githubHandle ?? '';
-        if (!memberId || !githubHandle) return null;
+        if (!memberId) return null;
         return { memberId, githubHandle };
       })
       .filter((row): row is MemberSummary => row !== null);


### PR DESCRIPTION
This pull request addresses an issue with handling business members whose Stripe subscription metadata may be missing a `githubHandle`. The logic is updated to ensure such members are still included in the results, maintaining accurate public counts. A corresponding test is added to verify this behavior.

**Stripe business member handling:**

* Updated `getBusinessMembers` logic in `StripeService` to include business members even if the `githubHandle` is missing in the subscription metadata, as older subscriptions may not have this field. This prevents public member counts from being underreported.
* Added a test in `stripe.service.spec.ts` to ensure business members without a `githubHandle` in metadata are still returned by `getBusinessMembers`.

**Miscellaneous:**

* Bumped backend package version from `0.3.1` to `0.3.2` in `package.json`.