### PR TITLE
feat: add event details for Cloud Native Maringá #3 with Call for Papers and future calendar

### DIFF
--- a/blog/2026-07-17-cloud-native-maringa-3-agile-brazil-c4p.mdx
+++ b/blog/2026-07-17-cloud-native-maringa-3-agile-brazil-c4p.mdx
@@ -1,0 +1,133 @@
+---
+title: "☁️ Cloud Native Maringá #3 com apoio da Agile Brazil — C4P aberto e calendário dos próximos encontros"
+date: 2026-07-17
+slug: 2026/07/17/cloud-native-maringa-3-agile-brazil-c4p
+tags:
+  - cloud-native
+  - cncf
+  - maringa
+  - eventos
+  - agile-brazil
+  - c4p
+authors:
+  - endersonmenezes
+---
+
+import Grid from '@mui/material/Grid';
+import Card from '@mui/material/Card';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import Button from '@mui/material/Button';
+import CampaignIcon from '@mui/icons-material/Campaign';
+import EventAvailableIcon from '@mui/icons-material/EventAvailable';
+import RecordVoiceOverIcon from '@mui/icons-material/RecordVoiceOver';
+
+Tem encontro novo no radar da comunidade: o **Cloud Native Maringá #3 com apoio da Agile Brazil** já está com **Call for Papers aberto**.
+
+Se você quer compartilhar experiências com Kubernetes, DevOps, SRE, plataforma, observabilidade e práticas cloud-native, essa é a hora de enviar sua proposta.
+
+<!-- truncate -->
+
+## 🚀 Visão rápida do evento
+
+<Grid container spacing={2} sx={{ my: 2 }}>
+  <Grid size={{ xs: 12, md: 4 }}>
+    <Card sx={{ height: '100%', borderLeft: '4px solid', borderColor: 'primary.main' }}>
+      <CardContent>
+        <Stack direction="row" spacing={1.5} alignItems="center" mb={1}>
+          <EventAvailableIcon sx={{ color: 'primary.main' }} />
+          <Typography variant="overline" color="text.secondary">Data e local</Typography>
+        </Stack>
+        <Typography variant="h6" fontWeight={800}>01 de agosto de 2026</Typography>
+        <Typography variant="body2" color="text.secondary">
+          09h30 às 12h00 (BRT)
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          UniCesumar - Inspira Space
+        </Typography>
+      </CardContent>
+    </Card>
+  </Grid>
+
+  <Grid size={{ xs: 12, md: 4 }}>
+    <Card sx={{ height: '100%', borderLeft: '4px solid', borderColor: 'secondary.main' }}>
+      <CardContent>
+        <Stack direction="row" spacing={1.5} alignItems="center" mb={1}>
+          <CampaignIcon sx={{ color: 'secondary.main' }} />
+          <Typography variant="overline" color="text.secondary">Call for Papers</Typography>
+        </Stack>
+        <Typography variant="h6" fontWeight={800}>Aberto até 18/07</Typography>
+        <Typography variant="body2" color="text.secondary">
+          Janela de submissão: 16/06 a 18/07/2026
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Capacity do evento: 100 pessoas
+        </Typography>
+      </CardContent>
+    </Card>
+  </Grid>
+
+  <Grid size={{ xs: 12, md: 4 }}>
+    <Card sx={{ height: '100%', borderLeft: '4px solid', borderColor: 'success.main' }}>
+      <CardContent>
+        <Stack direction="row" spacing={1.5} alignItems="center" mb={1}>
+          <RecordVoiceOverIcon sx={{ color: 'success.main' }} />
+          <Typography variant="overline" color="text.secondary">Formato das falas</Typography>
+        </Stack>
+        <Typography variant="body2" color="text.secondary">
+          Lightning Talks: 10 a 15 minutos
+        </Typography>
+        <Typography variant="body2" color="text.secondary">
+          Palestras padrão: 30 a 45 minutos
+        </Typography>
+      </CardContent>
+    </Card>
+  </Grid>
+</Grid>
+
+---
+
+## 💬 O que submeter?
+
+De acordo com a chamada oficial, qualquer tema em torno do ecossistema **CNCF** e tecnologias de nuvem é bem-vindo. O espaço é aberto tanto para quem está começando a palestrar quanto para quem já tem experiência com comunidade e open source.
+
+👉 Página oficial do evento (detalhes + submissão):
+**[Cloud Native Maringá #3 com apoio da Agile Brazil](https://ocgroups.dev/cncf/group/cloudnativemaringa/event/xw9tt8t)**
+
+---
+
+## 📅 Calendário futuro do Cloud Native Maringá
+
+Além do #3, a página do grupo já mostra os próximos encontros planejados:
+
+| Encontro | Data | Horário | Local |
+|---|---|---|---|
+| Cloud Native Maringá #4 | 29/08/2026 | 09h30 (BRT) | UniCIVE - Smart Space, Maringá |
+| Cloud Native Maringá #5 (com apoio da Agile Brazil) | 19/09/2026 | 09h30 (BRT) | Senac, Avenida Colombo, Maringá |
+| Cloud Native Maringá #6 | 24/10/2026 | 09h30 (BRT) | Maringá |
+
+<Button
+  variant="contained"
+  color="primary"
+  component="a"
+  href="https://ocgroups.dev/explore?entity=events&group%5B0%5D=cloudnativemaringa&community%5B0%5D=cncf"
+  target="_blank"
+  rel="noopener noreferrer"
+  sx={{ mt: 1.5 }}
+>
+  Ver calendário completo no Open Community Groups
+</Button>
+
+---
+
+## 🤝 Onde a Agile Brazil entra nisso?
+
+No site oficial da **Agile Brazil 2026**, a conferência é apresentada como iniciativa da comunidade com coordenação da Agile Alliance Brazil e voluntariado. No evento do Cloud Native Maringá, a Agile Brazil aparece como parceira de co-organização, conectando comunidades e fortalecendo o ecossistema local.
+
+🔗 Saiba mais sobre a Agile Brazil 2026:
+**[agilebrazil.com/2026/sobre](https://www.agilebrazil.com/2026/sobre)**
+
+---
+
+Nos vemos no próximo encontro! Se você tem algo legal para compartilhar com a comunidade, envie sua proposta e venha construir esse palco com a gente. 💚


### PR DESCRIPTION
This pull request adds a new blog post announcing the "Cloud Native Maringá #3" event, supported by Agile Brazil, and provides details about the event, its call for papers, and the upcoming event calendar. The post uses Material UI components for layout and includes links for more information and submission.

New blog post and event announcement:

* Added `blog/2026-07-17-cloud-native-maringa-3-agile-brazil-c4p.mdx` with details about the Cloud Native Maringá #3 event, including date, location, call for papers, session formats, and future events calendar.
* Integrated Material UI components (`Grid`, `Card`, `Stack`, etc.) to enhance the visual presentation of event information.
* Included official links for event submission and additional information about Agile Brazil 2026.