### PR TITLE
Develop

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - develop
       - main
+    paths-ignore:
+      - 'static/events/**/*.override.json'
+      - 'static/events/organizers.json'
+      - 'static/events/overrides-index.json'
+      - 'static/events/internal/**'
+      - 'static/events/index.json'
 
 concurrency:
   group: pr-check-${{ github.event.pull_request.number }}

--- a/.github/workflows/publish-backend.yml
+++ b/.github/workflows/publish-backend.yml
@@ -18,22 +18,22 @@ jobs:
         platform: [linux/amd64, linux/arm64/v8]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v6
+
       - name: Read Version
         id: version
         run: |
           VERSION=$(node -p "require('./backend/package.json').version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-        
+
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        
+        uses: docker/setup-qemu-action@v4
+
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        
+        uses: docker/setup-buildx-action@v4
+
       - name: Log in to the Container registry (GHCR)
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -84,14 +84,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
-        
+        uses: actions/checkout@v6
+
       - name: Read Version
         id: version
         run: |
           VERSION=$(node -p "require('./backend/package.json').version")
           echo "VERSION=$VERSION" >> $GITHUB_ENV
-        
+
       - name: Extract Release Notes
         id: notes
         run: |
@@ -110,7 +110,7 @@ jobs:
           echo "========================="
           
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: v${{ env.VERSION }}-backend
           name: Backend Versão ${{ env.VERSION }}

--- a/scripts/verify-override-author.mjs
+++ b/scripts/verify-override-author.mjs
@@ -5,8 +5,9 @@
 //   1. PRs que tocam organizers.json NUNCA passam (review manual obrigatório).
 //   2. Cada arquivo .override.json alterado deve declarar ownerHandle igual ao
 //      login GitHub do autor do PR (quem abriu o PR).
-//   3. O PR deve ter exatamente 1 commit, e esse commit deve ser do mesmo
-//      autor que abriu o PR (impede pushes extras no branch).
+//   3. Todos os commits do PR devem ser do mesmo autor que abriu o PR
+//      (impede pushes extras de terceiros no branch). Múltiplos commits do
+//      mesmo autor são permitidos — comum em ajustes rápidos após revisão.
 //   4. Snapshots internal e index.json são ignorados para fins de autor
 //      (gerados pelo force-sync do backend, que já loga quem solicitou).
 //
@@ -128,29 +129,30 @@ export async function verifyOverrideAuthor({
     }
   }
 
-  // Regra 3: exatamente 1 commit, do mesmo autor do PR.
+  // Regra 3: todos os commits devem ser do autor do PR.
   const commits = await getPrCommits(prNumber, repo, token, fetchImpl);
-  if (commits.length !== 1) {
+  if (commits.length === 0) {
     return {
       ok: false,
-      reason: `PR possui ${commits.length} commit(s). Apenas 1 commit permitido para auto-merge.`,
+      reason: "PR não possui commits — auto-merge bloqueado.",
     };
   }
 
-  const commitAuthor = commits[0].author?.login;
-  if (!commitAuthor) {
+  const divergentCommits = commits
+    .map((c) => c.author?.login)
+    .filter((login) => !login || login.toLowerCase() !== prAuthor.toLowerCase());
+  if (divergentCommits.length > 0) {
+    const offenders = commits
+      .map((c, i) => ({ index: i + 1, login: c.author?.login ?? "desconhecido" }))
+      .filter((c) => c.login.toLowerCase() !== prAuthor.toLowerCase());
+    const list = offenders.map((c) => `commit ${c.index} (@${c.login})`).join(", ");
     return {
       ok: false,
-      reason: "Commit não possui autor associado a uma conta GitHub.",
-    };
-  }
-  if (commitAuthor.toLowerCase() !== prAuthor.toLowerCase()) {
-    return {
-      ok: false,
-      reason: `Autor do commit (@${commitAuthor}) diverge do autor do PR (@${prAuthor}).`,
+      reason: `Autor de commit diverge do autor do PR (@${prAuthor}): ${list}.`,
     };
   }
 
+  const commitAuthor = commits[0].author.login;
   return { ok: true, prAuthor, commitAuthor, changedFiles };
 }
 

--- a/scripts/verify-override-author.test.mjs
+++ b/scripts/verify-override-author.test.mjs
@@ -128,7 +128,7 @@ test("verifyOverrideAuthor: ownerHandle diverge → bloqueado", async () => {
   assert.match(result.reason, /outrapessoa/);
 });
 
-test("verifyOverrideAuthor: mais de 1 commit → bloqueado", async () => {
+test("verifyOverrideAuthor: múltiplos commits do mesmo autor → ok", async () => {
   const { fetchImpl } = makeFetchMock({
     "/pulls/42": { body: { user: { login: "anadev" } } },
     "/pulls/42/files": { body: [{ filename: "static/events/meetup/devparana/123.override.json" }] },
@@ -149,8 +149,32 @@ test("verifyOverrideAuthor: mais de 1 commit → bloqueado", async () => {
     existsImpl: () => true,
   });
 
+  assert.equal(result.ok, true);
+});
+
+test("verifyOverrideAuthor: algum commit de autor divergente → bloqueado", async () => {
+  const { fetchImpl } = makeFetchMock({
+    "/pulls/42": { body: { user: { login: "anadev" } } },
+    "/pulls/42/files": { body: [{ filename: "static/events/meetup/devparana/123.override.json" }] },
+    "/pulls/42/commits": {
+      body: [
+        { author: { login: "anadev" }, commit: { author: { name: "Ana" } } },
+        { author: { login: "outro" }, commit: { author: { name: "Outro" } } },
+      ],
+    },
+  });
+
+  const result = await verifyOverrideAuthor({
+    prNumber: "42",
+    repo: "codaqui/institucional",
+    token: "tk",
+    fetchImpl,
+    readFileImpl: async () => JSON.stringify({ ownerHandle: "anadev" }),
+    existsImpl: () => true,
+  });
+
   assert.equal(result.ok, false);
-  assert.match(result.reason, /1 commit/);
+  assert.match(result.reason, /commit 2 \(@outro\)/);
 });
 
 test("verifyOverrideAuthor: autor do commit diverge → bloqueado", async () => {


### PR DESCRIPTION
This pull request updates workflow automation and improves the logic for verifying PR authorship in override files. The main changes include relaxing the commit author rule to allow multiple commits from the same author, updating and expanding related tests, and upgrading several GitHub Actions to their latest major versions.

**Workflow and Automation Improvements:**

* Updated the `.github/workflows/pr-check.yml` workflow to ignore changes in specific static event files, preventing unnecessary workflow runs for those files.
* Upgraded several GitHub Actions in `.github/workflows/publish-backend.yml` to their latest major versions (`actions/checkout@v6`, `docker/setup-qemu-action@v4`, `docker/setup-buildx-action@v4`, `docker/login-action@v4`, and `softprops/action-gh-release@v3`) for improved security and compatibility. [[1]](diffhunk://#diff-ff78c3d60e5d262794beeef1f475f992ab5be38903590b0495bb07a76d2cc507L21-R21) [[2]](diffhunk://#diff-ff78c3d60e5d262794beeef1f475f992ab5be38903590b0495bb07a76d2cc507L30-R36) [[3]](diffhunk://#diff-ff78c3d60e5d262794beeef1f475f992ab5be38903590b0495bb07a76d2cc507L87-R87) [[4]](diffhunk://#diff-ff78c3d60e5d262794beeef1f475f992ab5be38903590b0495bb07a76d2cc507L113-R113)

**Override Author Verification Logic:**

* Changed the override author verification script (`scripts/verify-override-author.mjs`) to allow multiple commits from the same author, rather than requiring a single commit, and improved error messaging for divergent commit authors. [[1]](diffhunk://#diff-78d9e98297137eaf9d9d1695ae66e6216426f308f5c388af5a5b6fcfa5fc509bL8-R10) [[2]](diffhunk://#diff-78d9e98297137eaf9d9d1695ae66e6216426f308f5c388af5a5b6fcfa5fc509bL131-R155)

**Test Enhancements:**

* Updated and expanded tests in `scripts/verify-override-author.test.mjs` to cover the new logic, including allowing multiple commits from the same author and blocking PRs with any commits from a different author. [[1]](diffhunk://#diff-2b19c347388bf581481a01d19f53bc5e79e364259e64f281df5efbfec6a5c793L131-R131) [[2]](diffhunk://#diff-2b19c347388bf581481a01d19f53bc5e79e364259e64f281df5efbfec6a5c793R152-R177)