### PR TITLE
chore(backend): bump para 0.8.0 e documenta convencao de versao

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,8 @@ npm run build       # Build completo igual ao CI
 cd backend && npm run build && npx jest --silent
 ```
 
+> ⚠️ **Mudança em `backend/` exige bump de `version` em `backend/package.json`** (semver: feat → minor, fix → patch). O workflow `publish-backend.yml` (manual) usa essa versão para a tag da imagem Docker no GHCR e para a release `v<versão>-backend` — sem bump, o deploy publica por cima da versão anterior.
+
 ---
 
 ## Directory Structure

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backend-codaqui",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "API for Codaqui Website and Intranet",
   "author": "Enderson Menezes Candido <enderson@codaqui.dev>",
   "private": true,


### PR DESCRIPTION
Mudancas de backend desde 0.7.2: reconciliacao de quota, organizers no payload publico, atomicidade de RSVP/cancelamento, description e slug em managed events, fixes stripe/expenses. AGENTS.md agora registra que mudanca em backend/ exige bump (publish-backend.yml usa a versao para tag da imagem e release)